### PR TITLE
ci(pages): redeploy docs on pushes to main under docs/**

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -5,6 +5,10 @@ on:
   push:
     tags:
       - "v*"
+    branches:
+      - main
+    paths:
+      - "docs/**"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Lets nebo-docs-bot sync commits (which write into docs/nebo/) trigger a
GitHub Pages rebuild. The existing v* tag trigger is preserved, and
workflow_dispatch remains for manual reruns.

https://claude.ai/code/session_016hdorhsNDTsyVDzWdsa6hr